### PR TITLE
Add `GetIFPresent` method.

### DIFF
--- a/arc_test.go
+++ b/arc_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/bluele/gcache"
 	"testing"
+	"time"
 )
 
 func buildARCache(size int) gcache.Cache {
@@ -59,5 +60,32 @@ func TestARCEvictItem(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
+	}
+}
+
+func TestARCGetIFPresent(t *testing.T) {
+	cache := gcache.
+		New(8).
+		LoaderFunc(
+		func(key interface{}) (interface{}, error) {
+			time.Sleep(100 * time.Millisecond)
+			return "value", nil
+		}).
+		ARC().
+		Build()
+
+	v, err := cache.GetIFPresent("key")
+	if err != gcache.NotFoundKeyError {
+		t.Errorf("err should not be %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	v, err = cache.GetIFPresent("key")
+	if err != nil {
+		t.Errorf("err should not be %v", err)
+	}
+	if v != "value" {
+		t.Errorf("v should not be %v", v)
 	}
 }

--- a/lfu.go
+++ b/lfu.go
@@ -71,6 +71,25 @@ func (c *LFUCache) set(key, value interface{}) (*lfuItem, error) {
 // If it dose not exists key and has LoaderFunc,
 // generate a value using `LoaderFunc` method returns value.
 func (c *LFUCache) Get(key interface{}) (interface{}, error) {
+	v, err := c.get(key)
+	if err != nil {
+		return c.getWithLoader(key, true)
+	}
+	return v, nil
+}
+
+// Get a value from cache pool using key if it exists.
+// If it dose not exists key, returns NotFoundKeyError.
+// And send a request which refresh value for specified key if cache object has LoaderFunc.
+func (c *LFUCache) GetIFPresent(key interface{}) (interface{}, error) {
+	v, err := c.get(key)
+	if err != nil {
+		return c.getWithLoader(key, false)
+	}
+	return v, nil
+}
+
+func (c *LFUCache) get(key interface{}) (interface{}, error) {
 	c.mu.RLock()
 	item, ok := c.items[key]
 	c.mu.RUnlock()
@@ -86,11 +105,13 @@ func (c *LFUCache) Get(key interface{}) (interface{}, error) {
 		c.removeItem(item)
 		c.mu.Unlock()
 	}
+	return nil, NotFoundKeyError
+}
 
+func (c *LFUCache) getWithLoader(key interface{}, isWait bool) (interface{}, error) {
 	if c.loaderFunc == nil {
 		return nil, NotFoundKeyError
 	}
-
 	it, err := c.load(key, func(v interface{}, e error) (interface{}, error) {
 		if e == nil {
 			c.mu.Lock()
@@ -98,7 +119,7 @@ func (c *LFUCache) Get(key interface{}) (interface{}, error) {
 			return c.set(key, v)
 		}
 		return nil, e
-	})
+	}, isWait)
 	if err != nil {
 		return nil, err
 	}

--- a/lfu_test.go
+++ b/lfu_test.go
@@ -68,3 +68,30 @@ func TestLFUEvictItem(t *testing.T) {
 		}
 	}
 }
+
+func TestLFUGetIFPresent(t *testing.T) {
+	cache := gcache.
+		New(8).
+		LoaderFunc(
+		func(key interface{}) (interface{}, error) {
+			time.Sleep(100 * time.Millisecond)
+			return "value", nil
+		}).
+		LFU().
+		Build()
+
+	v, err := cache.GetIFPresent("key")
+	if err != gcache.NotFoundKeyError {
+		t.Errorf("err should not be %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	v, err = cache.GetIFPresent("key")
+	if err != nil {
+		t.Errorf("err should not be %v", err)
+	}
+	if v != "value" {
+		t.Errorf("v should not be %v", v)
+	}
+}

--- a/lru_test.go
+++ b/lru_test.go
@@ -64,3 +64,30 @@ func TestLRUEvictItem(t *testing.T) {
 		}
 	}
 }
+
+func TestLRUGetIFPresent(t *testing.T) {
+	cache := gcache.
+		New(8).
+		LoaderFunc(
+		func(key interface{}) (interface{}, error) {
+			time.Sleep(100 * time.Millisecond)
+			return "value", nil
+		}).
+		LRU().
+		Build()
+
+	v, err := cache.GetIFPresent("key")
+	if err != gcache.NotFoundKeyError {
+		t.Errorf("err should not be %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	v, err = cache.GetIFPresent("key")
+	if err != nil {
+		t.Errorf("err should not be %v", err)
+	}
+	if v != "value" {
+		t.Errorf("v should not be %v", v)
+	}
+}

--- a/simple_test.go
+++ b/simple_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	gcache "github.com/bluele/gcache"
 	"testing"
+	"time"
 )
 
 func buildSimpleCache(size int) gcache.Cache {
@@ -59,5 +60,32 @@ func TestSimpleEvictItem(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
+	}
+}
+
+func TestSimpleGetIFPresent(t *testing.T) {
+	cache := gcache.
+		New(8).
+		LoaderFunc(
+		func(key interface{}) (interface{}, error) {
+			time.Sleep(100 * time.Millisecond)
+			return "value", nil
+		}).
+		Simple().
+		Build()
+
+	v, err := cache.GetIFPresent("key")
+	if err != gcache.NotFoundKeyError {
+		t.Errorf("err should not be %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	v, err = cache.GetIFPresent("key")
+	if err != nil {
+		t.Errorf("err should not be %v", err)
+	}
+	if v != "value" {
+		t.Errorf("v should not be %v", v)
 	}
 }

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package singleflight
+package gcache
 
 import (
 	"errors"


### PR DESCRIPTION
`GetIFPresent` immediately returns the value but will load the value in the background if specified key doesn't exist.
This comes handy if the value loader does some heavy task and should only run once per key.