### PR TITLE
Add clock interface, real and fake clocks

### DIFF
--- a/arc.go
+++ b/arc.go
@@ -70,7 +70,7 @@ func (c *ARC) SetWithExpire(key, value interface{}, expiration time.Duration) er
 		return err
 	}
 
-	t := time.Now().Add(expiration)
+	t := c.clock.Now().Add(expiration)
 	item.(*arcItem).expiration = &t
 	return nil
 }
@@ -89,6 +89,7 @@ func (c *ARC) set(key, value interface{}) (interface{}, error) {
 		item.value = value
 	} else {
 		item = &arcItem{
+			clock: c.clock,
 			key:   key,
 			value: value,
 		}
@@ -96,7 +97,7 @@ func (c *ARC) set(key, value interface{}) (interface{}, error) {
 	}
 
 	if c.expiration != nil {
-		t := time.Now().Add(*c.expiration)
+		t := c.clock.Now().Add(*c.expiration)
 		item.expiration = &t
 	}
 
@@ -243,7 +244,7 @@ func (c *ARC) getWithLoader(key interface{}, isWait bool) (interface{}, error) {
 			return nil, err
 		}
 		if expiration != nil {
-			t := time.Now().Add(*expiration)
+			t := c.clock.Now().Add(*expiration)
 			item.(*arcItem).expiration = &t
 		}
 		return v, nil
@@ -343,7 +344,7 @@ func (it *arcItem) IsExpired(now *time.Time) bool {
 		return false
 	}
 	if now == nil {
-		t := time.Now()
+		t := it.clock.Now()
 		now = &t
 	}
 	return it.expiration.Before(*now)
@@ -355,6 +356,7 @@ type arcList struct {
 }
 
 type arcItem struct {
+	clock      Clock
 	key        interface{}
 	value      interface{}
 	expiration *time.Time

--- a/arc_test.go
+++ b/arc_test.go
@@ -1,30 +1,28 @@
-package gcache_test
+package gcache
 
 import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/bluele/gcache"
 )
 
-func buildARCache(size int) gcache.Cache {
-	return gcache.New(size).
+func buildARCache(size int) Cache {
+	return New(size).
 		ARC().
 		EvictedFunc(evictedFuncForARC).
 		Build()
 }
 
-func buildLoadingARCache(size int) gcache.Cache {
-	return gcache.New(size).
+func buildLoadingARCache(size int) Cache {
+	return New(size).
 		ARC().
 		LoaderFunc(loader).
 		EvictedFunc(evictedFuncForARC).
 		Build()
 }
 
-func buildLoadingARCacheWithExpiration(size int, ep time.Duration) gcache.Cache {
-	return gcache.New(size).
+func buildLoadingARCacheWithExpiration(size int, ep time.Duration) Cache {
+	return New(size).
 		ARC().
 		Expiration(ep).
 		LoaderFunc(loader).
@@ -82,9 +80,9 @@ func TestARCEvictItem(t *testing.T) {
 }
 
 func TestARCGetIFPresent(t *testing.T) {
-	testGetIFPresent(t, gcache.TYPE_ARC)
+	testGetIFPresent(t, TYPE_ARC)
 }
 
 func TestARCGetALL(t *testing.T) {
-	testGetALL(t, gcache.TYPE_ARC)
+	testGetALL(t, TYPE_ARC)
 }

--- a/cache.go
+++ b/cache.go
@@ -31,6 +31,7 @@ type Cache interface {
 }
 
 type baseCache struct {
+	clock            Clock
 	size             int
 	loaderExpireFunc LoaderExpireFunc
 	evictedFunc      EvictedFunc
@@ -53,6 +54,7 @@ type (
 )
 
 type CacheBuilder struct {
+	clock            Clock
 	tp               string
 	size             int
 	loaderExpireFunc LoaderExpireFunc
@@ -68,9 +70,15 @@ func New(size int) *CacheBuilder {
 		panic("gcache: size <= 0")
 	}
 	return &CacheBuilder{
-		tp:   TYPE_SIMPLE,
-		size: size,
+		clock: NewRealClock(),
+		tp:    TYPE_SIMPLE,
+		size:  size,
 	}
+}
+
+func (cb *CacheBuilder) Clock(clock Clock) *CacheBuilder {
+	cb.clock = clock
+	return cb
 }
 
 // Set a loader function.
@@ -157,6 +165,7 @@ func (cb *CacheBuilder) build() Cache {
 }
 
 func buildCache(c *baseCache, cb *CacheBuilder) {
+	c.clock = cb.clock
 	c.size = cb.size
 	c.loaderExpireFunc = cb.loaderExpireFunc
 	c.expiration = cb.expiration

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,24 +1,21 @@
-package gcache_test
+package gcache
 
 import (
 	"bytes"
 	"encoding/gob"
-	"testing"
-	"time"
-
 	"sync"
 	"sync/atomic"
-
-	"github.com/bluele/gcache"
+	"testing"
+	"time"
 )
 
 func TestLoaderFunc(t *testing.T) {
 	size := 2
-	var testCaches = []*gcache.CacheBuilder{
-		gcache.New(size).Simple(),
-		gcache.New(size).LRU(),
-		gcache.New(size).LFU(),
-		gcache.New(size).ARC(),
+	var testCaches = []*CacheBuilder{
+		New(size).Simple(),
+		New(size).LRU(),
+		New(size).LFU(),
+		New(size).ARC(),
 	}
 	for _, builder := range testCaches {
 		var testCounter int64
@@ -53,11 +50,11 @@ func TestLoaderFunc(t *testing.T) {
 
 func TestLoaderExpireFuncWithoutExpire(t *testing.T) {
 	size := 2
-	var testCaches = []*gcache.CacheBuilder{
-		gcache.New(size).Simple(),
-		gcache.New(size).LRU(),
-		gcache.New(size).LFU(),
-		gcache.New(size).ARC(),
+	var testCaches = []*CacheBuilder{
+		New(size).Simple(),
+		New(size).LRU(),
+		New(size).LFU(),
+		New(size).ARC(),
 	}
 	for _, builder := range testCaches {
 		var testCounter int64
@@ -92,11 +89,11 @@ func TestLoaderExpireFuncWithoutExpire(t *testing.T) {
 
 func TestLoaderExpireFuncWithExpire(t *testing.T) {
 	size := 2
-	var testCaches = []*gcache.CacheBuilder{
-		gcache.New(size).Simple(),
-		gcache.New(size).LRU(),
-		gcache.New(size).LFU(),
-		gcache.New(size).ARC(),
+	var testCaches = []*CacheBuilder{
+		New(size).Simple(),
+		New(size).LRU(),
+		New(size).LFU(),
+		New(size).ARC(),
 	}
 	for _, builder := range testCaches {
 		var testCounter int64
@@ -143,16 +140,16 @@ func TestDeserializeFunc(t *testing.T) {
 	var cases = []struct {
 		tp string
 	}{
-		{gcache.TYPE_SIMPLE},
-		{gcache.TYPE_LRU},
-		{gcache.TYPE_LFU},
-		{gcache.TYPE_ARC},
+		{TYPE_SIMPLE},
+		{TYPE_LRU},
+		{TYPE_LFU},
+		{TYPE_ARC},
 	}
 
 	for _, cs := range cases {
 		key1, value1 := "key1", "value1"
 		key2, value2 := "key2", "value2"
-		cc := gcache.New(32).
+		cc := New(32).
 			EvictType(cs.tp).
 			LoaderFunc(func(k interface{}) (interface{}, error) {
 				return value1, nil

--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,53 @@
+package gcache
+
+import (
+	"sync"
+	"time"
+)
+
+type Clock interface {
+	Now() time.Time
+}
+
+type RealClock struct{}
+
+func NewRealClock() Clock {
+	return RealClock{}
+}
+
+func (rc RealClock) Now() time.Time {
+	t := time.Now()
+	return t
+}
+
+type FakeClock interface {
+	Clock
+
+	Advance(d time.Duration)
+}
+
+func NewFakeClock() FakeClock {
+	return &fakeclock{
+		// Taken from github.com/jonboulle/clockwork: use a fixture that does not fulfill Time.IsZero()
+		now: time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+type fakeclock struct {
+	now time.Time
+
+	mutex sync.RWMutex
+}
+
+func (fc *fakeclock) Now() time.Time {
+	fc.mutex.RLock()
+	defer fc.mutex.RUnlock()
+	t := fc.now
+	return t
+}
+
+func (fc *fakeclock) Advance(d time.Duration) {
+	fc.mutex.Lock()
+	defer fc.mutex.Unlock()
+	fc.now = fc.now.Add(d)
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,18 +1,16 @@
-package gcache_test
+package gcache
 
 import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/bluele/gcache"
 )
 
 func loader(key interface{}) (interface{}, error) {
 	return fmt.Sprintf("valueFor%s", key), nil
 }
 
-func testSetCache(t *testing.T, gc gcache.Cache, numbers int) {
+func testSetCache(t *testing.T, gc Cache, numbers int) {
 	for i := 0; i < numbers; i++ {
 		key := fmt.Sprintf("Key-%d", i)
 		value, err := loader(key)
@@ -24,7 +22,7 @@ func testSetCache(t *testing.T, gc gcache.Cache, numbers int) {
 	}
 }
 
-func testGetCache(t *testing.T, gc gcache.Cache, numbers int) {
+func testGetCache(t *testing.T, gc Cache, numbers int) {
 	for i := 0; i < numbers; i++ {
 		key := fmt.Sprintf("Key-%d", i)
 		v, err := gc.Get(key)
@@ -39,17 +37,17 @@ func testGetCache(t *testing.T, gc gcache.Cache, numbers int) {
 }
 
 func testGetIFPresent(t *testing.T, evT string) {
-	cache := gcache.
+	cache :=
 		New(8).
-		EvictType(evT).
-		LoaderFunc(
-			func(key interface{}) (interface{}, error) {
-				return "value", nil
-			}).
-		Build()
+			EvictType(evT).
+			LoaderFunc(
+				func(key interface{}) (interface{}, error) {
+					return "value", nil
+				}).
+			Build()
 
 	v, err := cache.GetIFPresent("key")
-	if err != gcache.KeyNotFoundError {
+	if err != KeyNotFoundError {
 		t.Errorf("err should not be %v", err)
 	}
 
@@ -66,11 +64,11 @@ func testGetIFPresent(t *testing.T, evT string) {
 
 func testGetALL(t *testing.T, evT string) {
 	size := 8
-	cache := gcache.
+	cache :=
 		New(size).
-		Expiration(time.Millisecond).
-		EvictType(evT).
-		Build()
+			Expiration(time.Millisecond).
+			EvictType(evT).
+			Build()
 	for i := 0; i < size; i++ {
 		cache.Set(i, i*i)
 	}

--- a/lfu.go
+++ b/lfu.go
@@ -47,7 +47,7 @@ func (c *LFUCache) SetWithExpire(key, value interface{}, expiration time.Duratio
 		return err
 	}
 
-	t := time.Now().Add(expiration)
+	t := c.clock.Now().Add(expiration)
 	item.(*lfuItem).expiration = &t
 	return nil
 }
@@ -71,6 +71,7 @@ func (c *LFUCache) set(key, value interface{}) (interface{}, error) {
 			c.evict(1)
 		}
 		item = &lfuItem{
+			clock:       c.clock,
 			key:         key,
 			value:       value,
 			freqElement: nil,
@@ -84,7 +85,7 @@ func (c *LFUCache) set(key, value interface{}) (interface{}, error) {
 	}
 
 	if c.expiration != nil {
-		t := time.Now().Add(*c.expiration)
+		t := c.clock.Now().Add(*c.expiration)
 		item.expiration = &t
 	}
 
@@ -165,7 +166,7 @@ func (c *LFUCache) getWithLoader(key interface{}, isWait bool) (interface{}, err
 			return nil, err
 		}
 		if expiration != nil {
-			t := time.Now().Add(*expiration)
+			t := c.clock.Now().Add(*expiration)
 			item.(*lfuItem).expiration = &t
 		}
 		return v, nil
@@ -292,6 +293,7 @@ type freqEntry struct {
 }
 
 type lfuItem struct {
+	clock       Clock
 	key         interface{}
 	value       interface{}
 	freqElement *list.Element
@@ -304,7 +306,7 @@ func (it *lfuItem) IsExpired(now *time.Time) bool {
 		return false
 	}
 	if now == nil {
-		t := time.Now()
+		t := it.clock.Now()
 		now = &t
 	}
 	return it.expiration.Before(*now)

--- a/lfu_test.go
+++ b/lfu_test.go
@@ -1,27 +1,25 @@
-package gcache_test
+package gcache
 
 import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/bluele/gcache"
 )
 
 func evictedFuncForLFU(key, value interface{}) {
 	fmt.Printf("[LFU] Key:%v Value:%v will evicted.\n", key, value)
 }
 
-func buildLFUCache(size int) gcache.Cache {
-	return gcache.New(size).
+func buildLFUCache(size int) Cache {
+	return New(size).
 		LFU().
 		EvictedFunc(evictedFuncForLFU).
 		Expiration(time.Second).
 		Build()
 }
 
-func buildLoadingLFUCache(size int, loader gcache.LoaderFunc) gcache.Cache {
-	return gcache.New(size).
+func buildLoadingLFUCache(size int, loader LoaderFunc) Cache {
+	return New(size).
 		LFU().
 		LoaderFunc(loader).
 		EvictedFunc(evictedFuncForLFU).
@@ -71,9 +69,9 @@ func TestLFUEvictItem(t *testing.T) {
 }
 
 func TestLFUGetIFPresent(t *testing.T) {
-	testGetIFPresent(t, gcache.TYPE_LFU)
+	testGetIFPresent(t, TYPE_LFU)
 }
 
 func TestLFUGetALL(t *testing.T) {
-	testGetALL(t, gcache.TYPE_LFU)
+	testGetALL(t, TYPE_LFU)
 }

--- a/lru.go
+++ b/lru.go
@@ -47,6 +47,7 @@ func (c *LRUCache) set(key, value interface{}) (interface{}, error) {
 			c.evict(1)
 		}
 		item = &lruItem{
+			clock: c.clock,
 			key:   key,
 			value: value,
 		}
@@ -54,7 +55,7 @@ func (c *LRUCache) set(key, value interface{}) (interface{}, error) {
 	}
 
 	if c.expiration != nil {
-		t := time.Now().Add(*c.expiration)
+		t := c.clock.Now().Add(*c.expiration)
 		item.expiration = &t
 	}
 
@@ -82,7 +83,7 @@ func (c *LRUCache) SetWithExpire(key, value interface{}, expiration time.Duratio
 		return err
 	}
 
-	t := time.Now().Add(expiration)
+	t := c.clock.Now().Add(expiration)
 	item.(*lruItem).expiration = &t
 	return nil
 }
@@ -158,7 +159,7 @@ func (c *LRUCache) getWithLoader(key interface{}, isWait bool) (interface{}, err
 			return nil, err
 		}
 		if expiration != nil {
-			t := time.Now().Add(*expiration)
+			t := c.clock.Now().Add(*expiration)
 			item.(*lruItem).expiration = &t
 		}
 		return v, nil
@@ -257,6 +258,7 @@ func (c *LRUCache) Purge() {
 }
 
 type lruItem struct {
+	clock      Clock
 	key        interface{}
 	value      interface{}
 	expiration *time.Time
@@ -268,7 +270,7 @@ func (it *lruItem) IsExpired(now *time.Time) bool {
 		return false
 	}
 	if now == nil {
-		t := time.Now()
+		t := it.clock.Now()
 		now = &t
 	}
 	return it.expiration.Before(*now)

--- a/lru_test.go
+++ b/lru_test.go
@@ -1,27 +1,25 @@
-package gcache_test
+package gcache
 
 import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/bluele/gcache"
 )
 
 func evictedFuncForLRU(key, value interface{}) {
 	fmt.Printf("[LRU] Key:%v Value:%v will evicted.\n", key, value)
 }
 
-func buildLRUCache(size int) gcache.Cache {
-	return gcache.New(size).
+func buildLRUCache(size int) Cache {
+	return New(size).
 		LRU().
 		EvictedFunc(evictedFuncForLRU).
 		Expiration(time.Second).
 		Build()
 }
 
-func buildLoadingLRUCache(size int, loader gcache.LoaderFunc) gcache.Cache {
-	return gcache.New(size).
+func buildLoadingLRUCache(size int, loader LoaderFunc) Cache {
+	return New(size).
 		LRU().
 		LoaderFunc(loader).
 		EvictedFunc(evictedFuncForLRU).
@@ -67,9 +65,9 @@ func TestLRUEvictItem(t *testing.T) {
 }
 
 func TestLRUGetIFPresent(t *testing.T) {
-	testGetIFPresent(t, gcache.TYPE_LRU)
+	testGetIFPresent(t, TYPE_LRU)
 }
 
 func TestLRUGetALL(t *testing.T) {
-	testGetALL(t, gcache.TYPE_LRU)
+	testGetALL(t, TYPE_LRU)
 }

--- a/simple_test.go
+++ b/simple_test.go
@@ -1,21 +1,19 @@
-package gcache_test
+package gcache
 
 import (
 	"fmt"
 	"testing"
-
-	gcache "github.com/bluele/gcache"
 )
 
-func buildSimpleCache(size int) gcache.Cache {
-	return gcache.New(size).
+func buildSimpleCache(size int) Cache {
+	return New(size).
 		Simple().
 		EvictedFunc(evictedFuncForSimple).
 		Build()
 }
 
-func buildLoadingSimpleCache(size int, loader gcache.LoaderFunc) gcache.Cache {
-	return gcache.New(size).
+func buildLoadingSimpleCache(size int, loader LoaderFunc) Cache {
+	return New(size).
 		LoaderFunc(loader).
 		Simple().
 		EvictedFunc(evictedFuncForSimple).
@@ -64,9 +62,9 @@ func TestSimpleEvictItem(t *testing.T) {
 }
 
 func TestSimpleGetIFPresent(t *testing.T) {
-	testGetIFPresent(t, gcache.TYPE_SIMPLE)
+	testGetIFPresent(t, TYPE_SIMPLE)
 }
 
 func TestSimpleGetALL(t *testing.T) {
-	testGetALL(t, gcache.TYPE_SIMPLE)
+	testGetALL(t, TYPE_SIMPLE)
 }


### PR DESCRIPTION
Discussion around the implementation of this can be found here: https://github.com/bluele/gcache/pull/31

One thing to note: I did not update the tests to use the fake clock, this is just making it capable of using the fake clock. @aaronwinter mentioned in the previous PR that he would help write those tests.

The current tests around the expiration are already flaky due to using the system clock, this change did not change the level of flakiness.