### PR TITLE
Extend SimpleCache to allow for unbounded growth

### DIFF
--- a/arc_test.go
+++ b/arc_test.go
@@ -31,7 +31,7 @@ func buildLoadingARCacheWithExpiration(size int, ep time.Duration) Cache {
 }
 
 func evictedFuncForARC(key, value interface{}) {
-	fmt.Printf("[ARC] Key:%v Value:%v will evicted.\n", key, value)
+	fmt.Printf("[ARC] Key:%v Value:%v will be evicted.\n", key, value)
 }
 
 func TestARCGet(t *testing.T) {

--- a/cache.go
+++ b/cache.go
@@ -66,9 +66,6 @@ type CacheBuilder struct {
 }
 
 func New(size int) *CacheBuilder {
-	if size <= 0 {
-		panic("gcache: size <= 0")
-	}
 	return &CacheBuilder{
 		clock: NewRealClock(),
 		tp:    TYPE_SIMPLE,
@@ -146,6 +143,10 @@ func (cb *CacheBuilder) Expiration(expiration time.Duration) *CacheBuilder {
 }
 
 func (cb *CacheBuilder) Build() Cache {
+	if cb.size <= 0 && cb.tp != TYPE_SIMPLE {
+		panic("gcache: Cache size <= 0")
+	}
+
 	return cb.build()
 }
 

--- a/lfu_test.go
+++ b/lfu_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func evictedFuncForLFU(key, value interface{}) {
-	fmt.Printf("[LFU] Key:%v Value:%v will evicted.\n", key, value)
+	fmt.Printf("[LFU] Key:%v Value:%v will be evicted.\n", key, value)
 }
 
 func buildLFUCache(size int) Cache {

--- a/lru_test.go
+++ b/lru_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func evictedFuncForLRU(key, value interface{}) {
-	fmt.Printf("[LRU] Key:%v Value:%v will evicted.\n", key, value)
+	fmt.Printf("[LRU] Key:%v Value:%v will be evicted.\n", key, value)
 }
 
 func buildLRUCache(size int) Cache {

--- a/simple.go
+++ b/simple.go
@@ -18,7 +18,11 @@ func newSimpleCache(cb *CacheBuilder) *SimpleCache {
 }
 
 func (c *SimpleCache) init() {
-	c.items = make(map[interface{}]*simpleItem, c.size)
+	if c.size == -1 {
+		c.items = make(map[interface{}]*simpleItem)
+	} else {
+		c.items = make(map[interface{}]*simpleItem, c.size)
+	}
 }
 
 // Set a new key-value pair
@@ -58,7 +62,7 @@ func (c *SimpleCache) set(key, value interface{}) (interface{}, error) {
 		item.value = value
 	} else {
 		// Verify size not exceeded
-		if len(c.items) >= c.size {
+		if (len(c.items) >= c.size) && c.size != -1 {
 			c.evict(1)
 		}
 		item = &simpleItem{

--- a/simple.go
+++ b/simple.go
@@ -18,7 +18,7 @@ func newSimpleCache(cb *CacheBuilder) *SimpleCache {
 }
 
 func (c *SimpleCache) init() {
-	if c.size == -1 {
+	if c.size <= 0 {
 		c.items = make(map[interface{}]*simpleItem)
 	} else {
 		c.items = make(map[interface{}]*simpleItem, c.size)
@@ -62,7 +62,7 @@ func (c *SimpleCache) set(key, value interface{}) (interface{}, error) {
 		item.value = value
 	} else {
 		// Verify size not exceeded
-		if (len(c.items) >= c.size) && c.size != -1 {
+		if (len(c.items) >= c.size) && c.size > 0 {
 			c.evict(1)
 		}
 		item = &simpleItem{

--- a/simple_test.go
+++ b/simple_test.go
@@ -61,6 +61,26 @@ func TestSimpleEvictItem(t *testing.T) {
 	}
 }
 
+func TestSimpleUnboundedNoEviction(t *testing.T) {
+	numbers := 1000
+	size_tracker := 0
+	gcu := buildLoadingSimpleCache(0, loader)
+
+	for i := 0; i < numbers; i++ {
+		current_size := gcu.Len()
+		if current_size != size_tracker {
+			t.Errorf("Excepted cache size is %v not %v", current_size, size_tracker)
+		}
+
+		_, err := gcu.Get(fmt.Sprintf("Key-%d", i))
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		size_tracker++
+	}
+}
+
 func TestSimpleGetIFPresent(t *testing.T) {
 	testGetIFPresent(t, TYPE_SIMPLE)
 }

--- a/simple_test.go
+++ b/simple_test.go
@@ -21,7 +21,7 @@ func buildLoadingSimpleCache(size int, loader LoaderFunc) Cache {
 }
 
 func evictedFuncForSimple(key, value interface{}) {
-	fmt.Printf("[Simple] Key:%v Value:%v will evicted.\n", key, value)
+	fmt.Printf("[Simple] Key:%v Value:%v will be evicted.\n", key, value)
 }
 
 func TestSimpleGet(t *testing.T) {


### PR DESCRIPTION
In this PR, we allow users to create a (SimpleCache) cache with no artificial upper bound on the number of elements that it can host. To achieve that, the user will specify a `size <= 0` before building the cache.