### PR TITLE
Replace runtime panics with bundled errors

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -155,7 +155,6 @@ func (cb *CacheBuilder) Expiration(expiration time.Duration) *CacheBuilder {
 
 func (cb *CacheBuilder) Build() Cache {
 	if cb.size <= 0 && cb.tp != TYPE_SIMPLE {
-		panic("gcache: Cache size <= 0")
 	}
 
 	return cb.build()
@@ -172,7 +171,6 @@ func (cb *CacheBuilder) build() Cache {
 	case TYPE_ARC:
 		return newARC(cb)
 	default:
-		panic("gcache: Unknown type " + cb.tp)
 	}
 }
 

--- a/cache.go
+++ b/cache.go
@@ -153,24 +153,26 @@ func (cb *CacheBuilder) Expiration(expiration time.Duration) *CacheBuilder {
 	return cb
 }
 
-func (cb *CacheBuilder) Build() Cache {
+func (cb *CacheBuilder) Build() (Cache, error) {
 	if cb.size <= 0 && cb.tp != TYPE_SIMPLE {
+		return newSimpleCache(cb), InvalidCacheSizeError
 	}
 
 	return cb.build()
 }
 
-func (cb *CacheBuilder) build() Cache {
+func (cb *CacheBuilder) build() (Cache, error) {
 	switch cb.tp {
 	case TYPE_SIMPLE:
-		return newSimpleCache(cb)
+		return newSimpleCache(cb), nil
 	case TYPE_LRU:
-		return newLRUCache(cb)
+		return newLRUCache(cb), nil
 	case TYPE_LFU:
-		return newLFUCache(cb)
+		return newLFUCache(cb), nil
 	case TYPE_ARC:
-		return newARC(cb)
+		return newARC(cb), nil
 	default:
+		return newSimpleCache(cb), UnknownCacheTypeError
 	}
 }
 

--- a/cache.go
+++ b/cache.go
@@ -15,6 +15,8 @@ const (
 )
 
 var KeyNotFoundError = errors.New("Key not found.")
+var InvalidCacheSizeError = errors.New("Invalid Cache size")
+var UnknownCacheTypeError = errors.New("Unknown Cache type")
 
 type Cache interface {
 	Set(interface{}, interface{}) error

--- a/examples/autoloading_cache.go
+++ b/examples/autoloading_cache.go
@@ -6,11 +6,11 @@ import (
 )
 
 func main() {
-	gc := gcache.New(10).
+	gc, _ := gcache.New(10).
 		LFU().
 		LoaderFunc(func(key interface{}) (interface{}, error) {
-		return fmt.Sprintf("%v-value", key), nil
-	}).
+			return fmt.Sprintf("%v-value", key), nil
+		}).
 		Build()
 
 	v, err := gc.Get("key")

--- a/examples/custom_expiration.go
+++ b/examples/custom_expiration.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	gc := gcache.New(10).
+	gc, _ := gcache.New(10).
 		LFU().
 		Build()
 

--- a/examples/example.go
+++ b/examples/example.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	gc := gcache.New(10).
+	gc, _ := gcache.New(10).
 		LFU().
 		Build()
 	gc.Set("key", "ok")

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -16,8 +16,8 @@ func testSetCache(t *testing.T, gc Cache, numbers int) {
 		value, err := loader(key)
 		if err != nil {
 			t.Error(err)
-			return
 		}
+
 		gc.Set(key, value)
 	}
 }
@@ -37,7 +37,7 @@ func testGetCache(t *testing.T, gc Cache, numbers int) {
 }
 
 func testGetIFPresent(t *testing.T, evT string) {
-	cache :=
+	cache, err :=
 		New(8).
 			EvictType(evT).
 			LoaderFunc(
@@ -45,6 +45,10 @@ func testGetIFPresent(t *testing.T, evT string) {
 					return "value", nil
 				}).
 			Build()
+
+	if err != nil {
+		t.Error(err)
+	}
 
 	v, err := cache.GetIFPresent("key")
 	if err != KeyNotFoundError {
@@ -64,11 +68,16 @@ func testGetIFPresent(t *testing.T, evT string) {
 
 func testGetALL(t *testing.T, evT string) {
 	size := 8
-	cache :=
+	cache, err :=
 		New(size).
 			Expiration(time.Millisecond).
 			EvictType(evT).
 			Build()
+
+	if err != nil {
+		t.Error(err)
+	}
+
 	for i := 0; i < size; i++ {
 		cache.Set(i, i*i)
 	}

--- a/lfu_test.go
+++ b/lfu_test.go
@@ -10,7 +10,7 @@ func evictedFuncForLFU(key, value interface{}) {
 	fmt.Printf("[LFU] Key:%v Value:%v will be evicted.\n", key, value)
 }
 
-func buildLFUCache(size int) Cache {
+func buildLFUCache(size int) (Cache, error) {
 	return New(size).
 		LFU().
 		EvictedFunc(evictedFuncForLFU).
@@ -18,7 +18,7 @@ func buildLFUCache(size int) Cache {
 		Build()
 }
 
-func buildLoadingLFUCache(size int, loader LoaderFunc) Cache {
+func buildLoadingLFUCache(size int, loader LoaderFunc) (Cache, error) {
 	return New(size).
 		LFU().
 		LoaderFunc(loader).
@@ -31,7 +31,11 @@ func TestLFUGet(t *testing.T) {
 	size := 1000
 	numbers := 1000
 
-	gc := buildLoadingLFUCache(size, loader)
+	gc, err := buildLoadingLFUCache(size, loader)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testSetCache(t, gc, numbers)
 	testGetCache(t, gc, numbers)
 }
@@ -40,12 +44,20 @@ func TestLoadingLFUGet(t *testing.T) {
 	size := 1000
 	numbers := 1000
 
-	gc := buildLoadingLFUCache(size, loader)
+	gc, err := buildLoadingLFUCache(size, loader)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testGetCache(t, gc, numbers)
 }
 
 func TestLFULength(t *testing.T) {
-	gc := buildLoadingLFUCache(1000, loader)
+	gc, err := buildLoadingLFUCache(1000, loader)
+	if err != nil {
+		t.Error(err)
+	}
+
 	gc.Get("test1")
 	gc.Get("test2")
 	length := gc.Len()
@@ -58,7 +70,10 @@ func TestLFULength(t *testing.T) {
 func TestLFUEvictItem(t *testing.T) {
 	cacheSize := 10
 	numbers := 11
-	gc := buildLoadingLFUCache(cacheSize, loader)
+	gc, err := buildLoadingLFUCache(cacheSize, loader)
+	if err != nil {
+		t.Error(err)
+	}
 
 	for i := 0; i < numbers; i++ {
 		_, err := gc.Get(fmt.Sprintf("Key-%d", i))

--- a/lru_test.go
+++ b/lru_test.go
@@ -10,7 +10,7 @@ func evictedFuncForLRU(key, value interface{}) {
 	fmt.Printf("[LRU] Key:%v Value:%v will be evicted.\n", key, value)
 }
 
-func buildLRUCache(size int) Cache {
+func buildLRUCache(size int) (Cache, error) {
 	return New(size).
 		LRU().
 		EvictedFunc(evictedFuncForLRU).
@@ -18,7 +18,7 @@ func buildLRUCache(size int) Cache {
 		Build()
 }
 
-func buildLoadingLRUCache(size int, loader LoaderFunc) Cache {
+func buildLoadingLRUCache(size int, loader LoaderFunc) (Cache, error) {
 	return New(size).
 		LRU().
 		LoaderFunc(loader).
@@ -29,19 +29,30 @@ func buildLoadingLRUCache(size int, loader LoaderFunc) Cache {
 
 func TestLRUGet(t *testing.T) {
 	size := 1000
-	gc := buildLRUCache(size)
+	gc, err := buildLRUCache(size)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testSetCache(t, gc, size)
 	testGetCache(t, gc, size)
 }
 
 func TestLoadingLRUGet(t *testing.T) {
 	size := 1000
-	gc := buildLoadingLRUCache(size, loader)
+	gc, err := buildLoadingLRUCache(size, loader)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testGetCache(t, gc, size)
 }
 
 func TestLRULength(t *testing.T) {
-	gc := buildLoadingLRUCache(1000, loader)
+	gc, err := buildLoadingLRUCache(1000, loader)
+	if err != nil {
+		t.Error(err)
+	}
 	gc.Get("test1")
 	gc.Get("test2")
 	length := gc.Len()
@@ -54,7 +65,10 @@ func TestLRULength(t *testing.T) {
 func TestLRUEvictItem(t *testing.T) {
 	cacheSize := 10
 	numbers := 11
-	gc := buildLoadingLRUCache(cacheSize, loader)
+	gc, err := buildLoadingLRUCache(cacheSize, loader)
+	if err != nil {
+		t.Error(err)
+	}
 
 	for i := 0; i < numbers; i++ {
 		_, err := gc.Get(fmt.Sprintf("Key-%d", i))

--- a/simple_test.go
+++ b/simple_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 )
 
-func buildSimpleCache(size int) Cache {
+func buildSimpleCache(size int) (Cache, error) {
 	return New(size).
 		Simple().
 		EvictedFunc(evictedFuncForSimple).
 		Build()
 }
 
-func buildLoadingSimpleCache(size int, loader LoaderFunc) Cache {
+func buildLoadingSimpleCache(size int, loader LoaderFunc) (Cache, error) {
 	return New(size).
 		LoaderFunc(loader).
 		Simple().
@@ -26,7 +26,11 @@ func evictedFuncForSimple(key, value interface{}) {
 
 func TestSimpleGet(t *testing.T) {
 	size := 1000
-	gc := buildSimpleCache(size)
+	gc, err := buildSimpleCache(size)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testSetCache(t, gc, size)
 	testGetCache(t, gc, size)
 }
@@ -34,11 +38,20 @@ func TestSimpleGet(t *testing.T) {
 func TestLoadingSimpleGet(t *testing.T) {
 	size := 1000
 	numbers := 1000
-	testGetCache(t, buildLoadingSimpleCache(size, loader), numbers)
+	gc, err := buildLoadingSimpleCache(size, loader)
+	if err != nil {
+		t.Error(err)
+	}
+
+	testGetCache(t, gc, numbers)
 }
 
 func TestSimpleLength(t *testing.T) {
-	gc := buildLoadingSimpleCache(1000, loader)
+	gc, err := buildLoadingSimpleCache(1000, loader)
+	if err != nil {
+		t.Error(err)
+	}
+
 	gc.Get("test1")
 	gc.Get("test2")
 	length := gc.Len()
@@ -51,7 +64,10 @@ func TestSimpleLength(t *testing.T) {
 func TestSimpleEvictItem(t *testing.T) {
 	cacheSize := 10
 	numbers := 11
-	gc := buildLoadingSimpleCache(cacheSize, loader)
+	gc, err := buildLoadingSimpleCache(cacheSize, loader)
+	if err != nil {
+		t.Error(err)
+	}
 
 	for i := 0; i < numbers; i++ {
 		_, err := gc.Get(fmt.Sprintf("Key-%d", i))
@@ -64,7 +80,10 @@ func TestSimpleEvictItem(t *testing.T) {
 func TestSimpleUnboundedNoEviction(t *testing.T) {
 	numbers := 1000
 	size_tracker := 0
-	gcu := buildLoadingSimpleCache(0, loader)
+	gcu, err := buildLoadingSimpleCache(0, loader)
+	if err != nil {
+		t.Error(err)
+	}
 
 	for i := 0; i < numbers; i++ {
 		current_size := gcu.Len()

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -27,7 +27,13 @@ import (
 
 func TestDo(t *testing.T) {
 	var g Group
-	g.cache = New(32).Build()
+	var err error
+
+	g.cache, err = New(32).Build()
+	if err != nil {
+		t.Error(err)
+	}
+
 	v, _, err := g.Do("key", func() (interface{}, error) {
 		return "bar", nil
 	}, true)
@@ -41,7 +47,13 @@ func TestDo(t *testing.T) {
 
 func TestDoErr(t *testing.T) {
 	var g Group
-	g.cache = New(32).Build()
+	var err error
+
+	g.cache, err = New(32).Build()
+	if err != nil {
+		t.Error(err)
+	}
+
 	someErr := errors.New("Some error")
 	v, _, err := g.Do("key", func() (interface{}, error) {
 		return nil, someErr
@@ -56,7 +68,13 @@ func TestDoErr(t *testing.T) {
 
 func TestDoDupSuppress(t *testing.T) {
 	var g Group
-	g.cache = New(32).Build()
+	var err error
+
+	g.cache, err = New(32).Build()
+	if err != nil {
+		t.Error(err)
+	}
+
 	c := make(chan string)
 	var calls int32
 	fn := func() (interface{}, error) {

--- a/stats_test.go
+++ b/stats_test.go
@@ -41,7 +41,11 @@ func TestCacheStats(t *testing.T) {
 	}{
 		{
 			builder: func() Cache {
-				cc := New(32).Simple().Build()
+				cc, err := New(32).Simple().Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)
@@ -51,7 +55,11 @@ func TestCacheStats(t *testing.T) {
 		},
 		{
 			builder: func() Cache {
-				cc := New(32).LRU().Build()
+				cc, err := New(32).LRU().Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)
@@ -61,7 +69,11 @@ func TestCacheStats(t *testing.T) {
 		},
 		{
 			builder: func() Cache {
-				cc := New(32).LFU().Build()
+				cc, err := New(32).LFU().Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)
@@ -71,7 +83,11 @@ func TestCacheStats(t *testing.T) {
 		},
 		{
 			builder: func() Cache {
-				cc := New(32).ARC().Build()
+				cc, err := New(32).ARC().Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)
@@ -81,10 +97,14 @@ func TestCacheStats(t *testing.T) {
 		},
 		{
 			builder: func() Cache {
-				cc := New(32).
+				cc, err := New(32).
 					Simple().
 					LoaderFunc(getter).
 					Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)
@@ -94,10 +114,14 @@ func TestCacheStats(t *testing.T) {
 		},
 		{
 			builder: func() Cache {
-				cc := New(32).
+				cc, err := New(32).
 					LRU().
 					LoaderFunc(getter).
 					Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)
@@ -107,10 +131,14 @@ func TestCacheStats(t *testing.T) {
 		},
 		{
 			builder: func() Cache {
-				cc := New(32).
+				cc, err := New(32).
 					LFU().
 					LoaderFunc(getter).
 					Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)
@@ -120,10 +148,14 @@ func TestCacheStats(t *testing.T) {
 		},
 		{
 			builder: func() Cache {
-				cc := New(32).
+				cc, err := New(32).
 					ARC().
 					LoaderFunc(getter).
 					Build()
+				if err != nil {
+					t.Error(err)
+				}
+
 				cc.Set(0, 0)
 				cc.Get(0)
 				cc.Get(1)


### PR DESCRIPTION
Issue #40 

This PR introduces breaking changes in the cache building API:

Previous function signature:
`func (cb *CacheBuilder) Build() Cache`

New function signature:
`func (cb *CacheBuilder) Build() (Cache, error)`

@bluele we should probably start proper versioning of the package to not catch users off-guard. 