### PR TITLE
Update Len() so it just looks at the length of the items

### DIFF
--- a/lfu.go
+++ b/lfu.go
@@ -276,7 +276,7 @@ func (c *LFUCache) GetALL() map[interface{}]interface{} {
 
 // Returns the number of items in the cache.
 func (c *LFUCache) Len() int {
-	return len(c.GetALL())
+	return len(c.items)
 }
 
 // Completely clear the cache

--- a/lru.go
+++ b/lru.go
@@ -246,7 +246,7 @@ func (c *LRUCache) GetALL() map[interface{}]interface{} {
 
 // Returns the number of items in the cache.
 func (c *LRUCache) Len() int {
-	return len(c.GetALL())
+	return len(c.items)
 }
 
 // Completely clear the cache

--- a/simple.go
+++ b/simple.go
@@ -237,7 +237,7 @@ func (c *SimpleCache) GetALL() map[interface{}]interface{} {
 
 // Returns the number of items in the cache.
 func (c *SimpleCache) Len() int {
-	return len(c.GetALL())
+	return len(c.items)
 }
 
 // Completely clear the cache


### PR DESCRIPTION
Currently, the different caches use `len(c.GetALL())` to figure out the number of items in the cache. This causes a problem with eviction order because `GetALL` does an underlying `GetIfPresent` on all keys in the cache. That `GetIfPresent` causes the metrics around each item (number of hits, last hit timestamp, etc.) to be updated. Therefore, when calling `Len()`, the eviction order is changed (in the case of the LRU, it's made random because it becomes map ordered).

@bluele Please note: I did not include ARC in here since it didn't pass the unit tests when I made this change. I am unsure as to the expected eviction behavior of ARC so I didn't want to go too far down the rabbit hole without consulting with you first.