### PR TITLE
Improve the efficiency of Keys(), GetALL(), and Len().

### DIFF
--- a/arc.go
+++ b/arc.go
@@ -303,7 +303,9 @@ func (c *ARC) keys() []interface{} {
 
 // Keys returns a slice of the keys in the cache.
 func (c *ARC) Keys() []interface{} {
-	keys := []interface{}{}
+	c.mu.RLock()
+	keys := make([]interface{}, 0, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		_, err := c.GetIFPresent(k)
 		if err == nil {
@@ -315,7 +317,9 @@ func (c *ARC) Keys() []interface{} {
 
 // Returns all key-value pairs in the cache.
 func (c *ARC) GetALL() map[interface{}]interface{} {
-	m := make(map[interface{}]interface{})
+	c.mu.RLock()
+	m := make(map[interface{}]interface{}, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		v, err := c.GetIFPresent(k)
 		if err == nil {
@@ -327,7 +331,7 @@ func (c *ARC) GetALL() map[interface{}]interface{} {
 
 // Len returns the number of items in the cache.
 func (c *ARC) Len() int {
-	return len(c.GetALL())
+	return len(c.Keys())
 }
 
 // Purge is used to completely clear the cache

--- a/lfu.go
+++ b/lfu.go
@@ -252,7 +252,9 @@ func (c *LFUCache) keys() []interface{} {
 
 // Returns a slice of the keys in the cache.
 func (c *LFUCache) Keys() []interface{} {
-	keys := []interface{}{}
+	c.mu.RLock()
+	keys := make([]interface{}, 0, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		_, err := c.GetIFPresent(k)
 		if err == nil {
@@ -264,7 +266,9 @@ func (c *LFUCache) Keys() []interface{} {
 
 // Returns all key-value pairs in the cache.
 func (c *LFUCache) GetALL() map[interface{}]interface{} {
-	m := make(map[interface{}]interface{})
+	c.mu.RLock()
+	m := make(map[interface{}]interface{}, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		v, err := c.GetIFPresent(k)
 		if err == nil {
@@ -276,7 +280,7 @@ func (c *LFUCache) GetALL() map[interface{}]interface{} {
 
 // Returns the number of items in the cache.
 func (c *LFUCache) Len() int {
-	return len(c.GetALL())
+	return len(c.Keys())
 }
 
 // Completely clear the cache

--- a/lru.go
+++ b/lru.go
@@ -222,7 +222,9 @@ func (c *LRUCache) keys() []interface{} {
 
 // Returns a slice of the keys in the cache.
 func (c *LRUCache) Keys() []interface{} {
-	keys := []interface{}{}
+	c.mu.RLock()
+	keys := make([]interface{}, 0, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		_, err := c.GetIFPresent(k)
 		if err == nil {
@@ -234,7 +236,9 @@ func (c *LRUCache) Keys() []interface{} {
 
 // Returns all key-value pairs in the cache.
 func (c *LRUCache) GetALL() map[interface{}]interface{} {
-	m := make(map[interface{}]interface{})
+	c.mu.RLock()
+	m := make(map[interface{}]interface{}, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		v, err := c.GetIFPresent(k)
 		if err == nil {
@@ -246,7 +250,7 @@ func (c *LRUCache) GetALL() map[interface{}]interface{} {
 
 // Returns the number of items in the cache.
 func (c *LRUCache) Len() int {
-	return len(c.GetALL())
+	return len(c.Keys())
 }
 
 // Completely clear the cache

--- a/simple.go
+++ b/simple.go
@@ -213,7 +213,9 @@ func (c *SimpleCache) keys() []interface{} {
 
 // Returns a slice of the keys in the cache.
 func (c *SimpleCache) Keys() []interface{} {
-	keys := []interface{}{}
+	c.mu.RLock()
+	keys := make([]interface{}, 0, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		_, err := c.GetIFPresent(k)
 		if err == nil {
@@ -225,7 +227,9 @@ func (c *SimpleCache) Keys() []interface{} {
 
 // Returns all key-value pairs in the cache.
 func (c *SimpleCache) GetALL() map[interface{}]interface{} {
-	m := make(map[interface{}]interface{})
+	c.mu.RLock()
+	m := make(map[interface{}]interface{}, len(c.items))
+	c.mu.RUnlock()
 	for _, k := range c.keys() {
 		v, err := c.GetIFPresent(k)
 		if err == nil {
@@ -237,7 +241,7 @@ func (c *SimpleCache) GetALL() map[interface{}]interface{} {
 
 // Returns the number of items in the cache.
 func (c *SimpleCache) Len() int {
-	return len(c.GetALL())
+	return len(c.Keys())
 }
 
 // Completely clear the cache


### PR DESCRIPTION
Preallocate the maximum number of available items, including expired items.  While this isn't optimal, it is a reasonable guess for the length.

Even though this approach results in one extra mutex acquisition, in simple `go test` benchmarking, this improves the test time from ~1.444s to ~1.332s.  Presumably this improvement is the result of two things:

1. reduced GC pressure on the GC
2. reduced time that `c.mu` is locked while the GC copies data around

There is still room to be had by reducing the number of times `c.mu` is exclusively locked, but this is an easy performance improvement.

Fixes: #43
Replaces: #50