### PR TITLE
fix bug:length of evictList maybe bigger more than c.size

### DIFF
--- a/lfu.go
+++ b/lfu.go
@@ -68,7 +68,7 @@ func (c *LFUCache) set(key, value interface{}) (interface{}, error) {
 	} else {
 		// Verify size not exceeded
 		if len(c.items) >= c.size {
-			c.evict(1)
+			c.evict(len(c.items) - c.size - 1)
 		}
 		item = &lfuItem{
 			clock:       c.clock,

--- a/lru.go
+++ b/lru.go
@@ -44,7 +44,7 @@ func (c *LRUCache) set(key, value interface{}) (interface{}, error) {
 	} else {
 		// Verify size not exceeded
 		if c.evictList.Len() >= c.size {
-			c.evict(1)
+			c.evict(c.evictList.Len() - c.size - 1)
 		}
 		item = &lruItem{
 			clock: c.clock,


### PR DESCRIPTION
If a bug occurs in other place, that cause the length of evictList is bigger than c.size+1, after this code `c.evict(1)`, the cache is still full。