### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/arc.go
+++ b/arc.go
@@ -171,7 +171,7 @@ func (c *ARC) Get(key interface{}) (interface{}, error) {
 	return v, err
 }
 
-// Get a value from cache pool using key if it exists.
+// GetIFPresent gets a value from cache pool using key if it exists.
 // If it dose not exists key, returns KeyNotFoundError.
 // And send a request which refresh value for specified key if cache object has LoaderFunc.
 func (c *ARC) GetIFPresent(key interface{}) (interface{}, error) {
@@ -337,7 +337,7 @@ func (c *ARC) Keys() []interface{} {
 	return keys
 }
 
-// Returns all key-value pairs in the cache.
+// GetALL returns all key-value pairs in the cache.
 func (c *ARC) GetALL() map[interface{}]interface{} {
 	m := make(map[interface{}]interface{})
 	for _, k := range c.keys() {
@@ -378,7 +378,7 @@ func (c *ARC) isCacheFull() bool {
 	return (c.t1.Len() + c.t2.Len()) == c.size
 }
 
-// returns boolean value whether this item is expired or not.
+// IsExpired returns boolean value whether this item is expired or not.
 func (it *arcItem) IsExpired(now *time.Time) bool {
 	if it.expiration == nil {
 		return false

--- a/lfu.go
+++ b/lfu.go
@@ -107,7 +107,7 @@ func (c *LFUCache) Get(key interface{}) (interface{}, error) {
 	return v, err
 }
 
-// Get a value from cache pool using key if it exists.
+// GetIFPresent gets a value from cache pool using key if it exists.
 // If it dose not exists key, returns KeyNotFoundError.
 // And send a request which refresh value for specified key if cache object has LoaderFunc.
 func (c *LFUCache) GetIFPresent(key interface{}) (interface{}, error) {
@@ -229,7 +229,7 @@ func (c *LFUCache) has(key interface{}, now *time.Time) bool {
 	return !item.IsExpired(now)
 }
 
-// Removes the provided key from the cache.
+// Remove removes the provided key from the cache.
 func (c *LFUCache) Remove(key interface{}) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -266,7 +266,7 @@ func (c *LFUCache) keys() []interface{} {
 	return keys
 }
 
-// Returns a slice of the keys in the cache.
+// Keys returns a slice of the keys in the cache.
 func (c *LFUCache) Keys() []interface{} {
 	keys := []interface{}{}
 	for _, k := range c.keys() {
@@ -278,7 +278,7 @@ func (c *LFUCache) Keys() []interface{} {
 	return keys
 }
 
-// Returns all key-value pairs in the cache.
+// GetALL returns all key-value pairs in the cache.
 func (c *LFUCache) GetALL() map[interface{}]interface{} {
 	m := make(map[interface{}]interface{})
 	for _, k := range c.keys() {
@@ -290,7 +290,7 @@ func (c *LFUCache) GetALL() map[interface{}]interface{} {
 	return m
 }
 
-// Returns the number of items in the cache.
+// Len returns the number of items in the cache.
 func (c *LFUCache) Len() int {
 	return len(c.GetALL())
 }
@@ -322,7 +322,7 @@ type lfuItem struct {
 	expiration  *time.Time
 }
 
-// returns boolean value whether this item is expired or not.
+// IsExpired returns boolean value whether this item is expired or not.
 func (it *lfuItem) IsExpired(now *time.Time) bool {
 	if it.expiration == nil {
 		return false

--- a/lru.go
+++ b/lru.go
@@ -99,7 +99,7 @@ func (c *LRUCache) Get(key interface{}) (interface{}, error) {
 	return v, err
 }
 
-// Get a value from cache pool using key if it exists.
+// GetIFPresent gets a value from cache pool using key if it exists.
 // If it dose not exists key, returns KeyNotFoundError.
 // And send a request which refresh value for specified key if cache object has LoaderFunc.
 func (c *LRUCache) GetIFPresent(key interface{}) (interface{}, error) {
@@ -198,7 +198,7 @@ func (c *LRUCache) has(key interface{}, now *time.Time) bool {
 	return !item.Value.(*lruItem).IsExpired(now)
 }
 
-// Removes the provided key from the cache.
+// Remove removes the provided key from the cache.
 func (c *LRUCache) Remove(key interface{}) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -236,7 +236,7 @@ func (c *LRUCache) keys() []interface{} {
 	return keys
 }
 
-// Returns a slice of the keys in the cache.
+// Keys returns a slice of the keys in the cache.
 func (c *LRUCache) Keys() []interface{} {
 	keys := []interface{}{}
 	for _, k := range c.keys() {
@@ -248,7 +248,7 @@ func (c *LRUCache) Keys() []interface{} {
 	return keys
 }
 
-// Returns all key-value pairs in the cache.
+// GetALL returns all key-value pairs in the cache.
 func (c *LRUCache) GetALL() map[interface{}]interface{} {
 	m := make(map[interface{}]interface{})
 	for _, k := range c.keys() {
@@ -260,7 +260,7 @@ func (c *LRUCache) GetALL() map[interface{}]interface{} {
 	return m
 }
 
-// Returns the number of items in the cache.
+// Len returns the number of items in the cache.
 func (c *LRUCache) Len() int {
 	return len(c.GetALL())
 }
@@ -288,7 +288,7 @@ type lruItem struct {
 	expiration *time.Time
 }
 
-// returns boolean value whether this item is expired or not.
+// IsExpired returns boolean value whether this item is expired or not.
 func (it *lruItem) IsExpired(now *time.Time) bool {
 	if it.expiration == nil {
 		return false

--- a/simple.go
+++ b/simple.go
@@ -95,7 +95,7 @@ func (c *SimpleCache) Get(key interface{}) (interface{}, error) {
 	return v, err
 }
 
-// Get a value from cache pool using key if it exists.
+// GetIFPresent gets a value from cache pool using key if it exists.
 // If it dose not exists key, returns KeyNotFoundError.
 // And send a request which refresh value for specified key if cache object has LoaderFunc.
 func (c *SimpleCache) GetIFPresent(key interface{}) (interface{}, error) {
@@ -194,7 +194,7 @@ func (c *SimpleCache) has(key interface{}, now *time.Time) bool {
 	return !item.IsExpired(now)
 }
 
-// Removes the provided key from the cache.
+// Remove removes the provided key from the cache.
 func (c *SimpleCache) Remove(key interface{}) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -227,7 +227,7 @@ func (c *SimpleCache) keys() []interface{} {
 	return keys
 }
 
-// Returns a slice of the keys in the cache.
+// Keys returns a slice of the keys in the cache.
 func (c *SimpleCache) Keys() []interface{} {
 	keys := []interface{}{}
 	for _, k := range c.keys() {
@@ -239,7 +239,7 @@ func (c *SimpleCache) Keys() []interface{} {
 	return keys
 }
 
-// Returns all key-value pairs in the cache.
+// GetALL returns all key-value pairs in the cache.
 func (c *SimpleCache) GetALL() map[interface{}]interface{} {
 	m := make(map[interface{}]interface{})
 	for _, k := range c.keys() {
@@ -251,7 +251,7 @@ func (c *SimpleCache) GetALL() map[interface{}]interface{} {
 	return m
 }
 
-// Returns the number of items in the cache.
+// Len returns the number of items in the cache.
 func (c *SimpleCache) Len() int {
 	return len(c.GetALL())
 }
@@ -276,7 +276,7 @@ type simpleItem struct {
 	expiration *time.Time
 }
 
-// returns boolean value whether this item is expired or not.
+// IsExpired returns boolean value whether this item is expired or not.
 func (si *simpleItem) IsExpired(now *time.Time) bool {
 	if si.expiration == nil {
 		return false


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?